### PR TITLE
Fix formatPkgInfo so it displays actual installed

### DIFF
--- a/php/PhoneBocx/Packages.php
+++ b/php/PhoneBocx/Packages.php
@@ -348,7 +348,7 @@ class Packages
 
         // This is so that we don't need to push out a bunch of
         // identical builds just to change the name.
-        return self::getPkgVer($i['remote']);
+        return self::getPkgVer($i['local']);
     }
 
     public static function getPackageDownloadInfo(string $name, bool $refresh = false)


### PR DESCRIPTION
formatPkgInfo is used to output the "Currently Installed" package list but the default is to return remote instead of local version so we don't see the actual currently installed version, but the currently offered remote version instead.